### PR TITLE
Add Prometheus instrumentation in nexus-metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1764,6 +1770,16 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nexus-metrics"
+version = "0.1.0"
+dependencies = [
+ "nexus-common",
+ "once_cell",
+ "prometheus",
  "tracing",
 ]
 
@@ -2185,6 +2201,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot 0.12.5",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2292,12 @@ checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quinn"
@@ -2585,6 +2647,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2592,7 +2667,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3226,7 +3301,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "nexus-control",
   "nexus-gateway",
   "nexus-lb",
+  "nexus-metrics",
 ]
 resolver = "2"
 
@@ -78,6 +79,7 @@ nexus-lb      = { path = "nexus-lb" }
 nexus-ml-client = { path = "nexus-ml-client" }
 nexus-control = { path = "nexus-control" }
 nexus-pipeline = { path = "nexus-pipeline" }
+nexus-metrics = { path = "nexus-metrics" }
 
 [profile.release]
 opt-level     = 3

--- a/nexus-metrics/Cargo.toml
+++ b/nexus-metrics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "nexus-metrics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nexus-common = { path = "../nexus-common" }
+prometheus = { workspace = true }
+once_cell = { workspace = true }
+tracing = { workspace = true }

--- a/nexus-metrics/examples/demo.rs
+++ b/nexus-metrics/examples/demo.rs
@@ -1,0 +1,92 @@
+//! Demo program to test nexus-metrics functionality.
+//!
+//! Run with: cargo run -p nexus-metrics --example demo
+
+use std::time::Duration;
+
+fn main() {
+    println!("🚀 Nexus Metrics Demo\n");
+    
+    // Initialize metrics
+    println!("Initializing metrics...");
+    nexus_metrics::init();
+    println!("✓ Metrics initialized\n");
+    
+    // Simulate some requests
+    println!("Simulating HTTP requests...");
+    nexus_metrics::record_request("GET", 200);
+    nexus_metrics::record_request("GET", 200);
+    nexus_metrics::record_request("POST", 200);
+    nexus_metrics::record_request("GET", 403);
+    nexus_metrics::record_request_duration(Duration::from_millis(42));
+    nexus_metrics::record_request_duration(Duration::from_millis(8));
+    nexus_metrics::record_request_duration(Duration::from_millis(156));
+    println!("✓ Recorded 4 requests\n");
+    
+    // Simulate attacks being blocked
+    println!("Simulating blocked attacks...");
+    nexus_metrics::record_blocked("sqli");
+    nexus_metrics::record_blocked("sqli");
+    nexus_metrics::record_blocked("xss");
+    nexus_metrics::record_blocked("rule:R001");
+    println!("✓ Recorded 4 blocks\n");
+    
+    // Simulate layer processing
+    println!("Simulating layer processing...");
+    nexus_metrics::record_layer_duration("rate", Duration::from_micros(100));
+    nexus_metrics::record_layer_duration("lexical", Duration::from_micros(150));
+    nexus_metrics::record_layer_duration("grammar", Duration::from_micros(800));
+    nexus_metrics::record_layer_duration("rules", Duration::from_micros(200));
+    nexus_metrics::record_layer_duration("ml", Duration::from_millis(12));
+    println!("✓ Recorded 5 layer timings\n");
+    
+    // Simulate ML inference
+    println!("Simulating ML inference...");
+    nexus_metrics::record_ml_inference(Duration::from_millis(8), true);  // detected
+    nexus_metrics::record_ml_inference(Duration::from_millis(5), false); // clean
+    nexus_metrics::record_ml_inference(Duration::from_millis(12), true); // detected
+    println!("✓ Recorded 3 ML inferences (2 detections)\n");
+    
+    // Update gauges
+    println!("Updating gauges...");
+    nexus_metrics::set_active_connections(42);
+    nexus_metrics::set_upstream_health("192.168.1.10:8080", true);
+    nexus_metrics::set_upstream_health("192.168.1.11:8080", false);
+    nexus_metrics::set_upstream_health("192.168.1.12:8080", true);
+    println!("✓ Updated connection count and upstream health\n");
+    
+    // Simulate rate limiting
+    println!("Simulating rate limiting...");
+    nexus_metrics::record_rate_limited("203.0.113.42");
+    nexus_metrics::record_rate_limited("203.0.113.42");
+    nexus_metrics::record_rate_limited("198.51.100.1");
+    println!("✓ Recorded 3 rate limits\n");
+    
+    // Simulate rule matches
+    println!("Simulating rule matches...");
+    nexus_metrics::record_rule_match("R001", "block");
+    nexus_metrics::record_rule_match("R002", "log");
+    nexus_metrics::record_rule_match("R003", "allow");
+    nexus_metrics::record_rule_match("R001", "block");
+    println!("✓ Recorded 4 rule matches\n");
+    
+    // Gather and display metrics
+    println!("{}", "=".repeat(80));
+    println!("📊 PROMETHEUS METRICS OUTPUT");
+    println!("{}", "=".repeat(80));
+    println!();
+    
+    let metrics = nexus_metrics::gather_metrics();
+    println!("{}", metrics);
+    
+    println!("{}", "=".repeat(80));
+    println!("\n✅ Demo complete! All metrics recorded successfully.");
+    println!("\nKey observations:");
+    println!("  • nexus_requests_total: Should show GET=3, POST=1");
+    println!("  • nexus_blocked_requests_total: Should show sqli=2, xss=1, rule:R001=1");
+    println!("  • nexus_ml_detections_total: Should be 2");
+    println!("  • nexus_active_connections: Should be 42");
+    println!("  • nexus_upstream_health: Should show 3 upstreams (2 healthy, 1 unhealthy)");
+    println!("  • nexus_rate_limited_total: Should show 2 IPs");
+    println!("  • nexus_rule_matches_total: Should show 4 matches across 3 rules");
+}

--- a/nexus-metrics/src/exporter.rs
+++ b/nexus-metrics/src/exporter.rs
@@ -1,0 +1,30 @@
+//! Prometheus text format exporter.
+//!
+//! Provides the `/metrics` endpoint output in Prometheus exposition format.
+
+use prometheus::{Encoder, TextEncoder};
+
+/// Gather all registered metrics and encode them in Prometheus text format.
+///
+/// This is the function that powers the `/metrics` HTTP endpoint.
+///
+/// # Example
+/// ```
+/// let metrics_output = nexus_metrics::gather_metrics();
+/// println!("{}", metrics_output);
+/// ```
+pub fn gather_metrics() -> String {
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&metric_families, &mut buffer) {
+        tracing::error!("failed to encode metrics: {}", e);
+        return String::from("# encoding error\n");
+    }
+    
+    String::from_utf8(buffer).unwrap_or_else(|e| {
+        tracing::error!("failed to convert metrics to UTF-8: {}", e);
+        String::from("# UTF-8 conversion error\n")
+    })
+}

--- a/nexus-metrics/src/lib.rs
+++ b/nexus-metrics/src/lib.rs
@@ -1,0 +1,262 @@
+//! Nexus Metrics — Prometheus instrumentation for the Nexus WAF.
+//!
+//! This crate provides comprehensive observability for the Nexus system:
+//! - Request rates and latency percentiles
+//! - Block rates by attack type
+//! - Per-layer processing time
+//! - ML inference metrics
+//! - Upstream health status
+//!
+//! # Usage
+//!
+//! Initialize metrics at startup:
+//! ```
+//! nexus_metrics::init();
+//! ```
+//!
+//! Record events throughout your application:
+//! ```
+//! use std::time::Duration;
+//!
+//! // Record a successful request
+//! nexus_metrics::record_request("GET", 200);
+//! nexus_metrics::record_request_duration(Duration::from_millis(42));
+//!
+//! // Record a blocked attack
+//! nexus_metrics::record_blocked("sqli");
+//!
+//! // Record layer timing
+//! nexus_metrics::record_layer_duration("lexical", Duration::from_micros(150));
+//!
+//! // Record ML inference
+//! nexus_metrics::record_ml_inference(Duration::from_millis(8), true);
+//!
+//! // Update gauges
+//! nexus_metrics::set_active_connections(42);
+//! nexus_metrics::set_upstream_health("192.168.1.10:8080", true);
+//!
+//! // Record rate limiting and rule matches
+//! nexus_metrics::record_rate_limited("203.0.113.42");
+//! nexus_metrics::record_rule_match("R001", "block");
+//! ```
+//!
+//! Export metrics for Prometheus scraping:
+//! ```
+//! let output = nexus_metrics::gather_metrics();
+//! // Serve this at GET /metrics
+//! ```
+
+mod exporter;
+mod metrics;
+mod recorder;
+
+// Re-export public API
+pub use exporter::gather_metrics;
+pub use recorder::{
+    record_blocked, record_layer_duration, record_ml_inference, record_rate_limited,
+    record_request, record_request_duration, record_rule_match, set_active_connections,
+    set_upstream_health,
+};
+
+/// Initialize the metrics subsystem.
+///
+/// This forces registration of all metrics with the global Prometheus registry,
+/// ensuring they appear in the first scrape even before any requests arrive.
+///
+/// Safe to call multiple times; subsequent calls are no-ops.
+///
+/// # Example
+/// ```
+/// nexus_metrics::init();
+/// ```
+pub fn init() {
+    metrics::register_all();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_init_does_not_panic() {
+        init();
+        init(); // Should be safe to call multiple times
+    }
+
+    #[test]
+    fn test_record_request() {
+        record_request("GET", 200);
+        record_request("POST", 403);
+        // Verify metrics contain expected labels
+        let output = gather_metrics();
+        assert!(output.contains("nexus_requests_total"));
+    }
+
+    #[test]
+    fn test_record_request_duration() {
+        record_request_duration(Duration::from_millis(42));
+        record_request_duration(Duration::from_secs(1));
+        let output = gather_metrics();
+        assert!(output.contains("nexus_request_duration_ms"));
+    }
+
+    #[test]
+    fn test_record_blocked() {
+        record_blocked("sqli");
+        record_blocked("xss");
+        record_blocked("rule:R001");
+        let output = gather_metrics();
+        assert!(output.contains("nexus_blocked_requests_total"));
+    }
+
+    #[test]
+    fn test_record_layer_duration() {
+        record_layer_duration("rate", Duration::from_micros(100));
+        record_layer_duration("lexical", Duration::from_micros(150));
+        record_layer_duration("grammar", Duration::from_millis(1));
+        record_layer_duration("rules", Duration::from_micros(200));
+        record_layer_duration("ml", Duration::from_millis(10));
+        let output = gather_metrics();
+        assert!(output.contains("nexus_layer_duration_us"));
+    }
+
+    #[test]
+    fn test_record_ml_inference_with_detection() {
+        let before = gather_metrics();
+        let count_before = before
+            .lines()
+            .find(|line| line.starts_with("nexus_ml_detections_total"))
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        record_ml_inference(Duration::from_millis(8), true);
+
+        let after = gather_metrics();
+        let count_after = after
+            .lines()
+            .find(|line| line.starts_with("nexus_ml_detections_total"))
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        assert!(count_after > count_before, "ML detection counter should increase");
+    }
+
+    #[test]
+    fn test_record_ml_inference_without_detection() {
+        init(); // Ensure metric exists
+        
+        let before = gather_metrics();
+        let count_before = before
+            .lines()
+            .find(|line| line.starts_with("nexus_ml_detections_total"))
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        record_ml_inference(Duration::from_millis(5), false);
+
+        let after = gather_metrics();
+        let count_after = after
+            .lines()
+            .find(|line| line.starts_with("nexus_ml_detections_total"))
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        assert_eq!(count_after, count_before, "ML detection counter should not increase when detected=false");
+    }
+
+    #[test]
+    fn test_set_active_connections() {
+        set_active_connections(42);
+        set_active_connections(0);
+        set_active_connections(-5); // Should work with negative values
+        let output = gather_metrics();
+        assert!(output.contains("nexus_active_connections"));
+    }
+
+    #[test]
+    fn test_set_upstream_health() {
+        set_upstream_health("192.168.1.10:8080", true);
+        let output_healthy = gather_metrics();
+        assert!(output_healthy.contains("nexus_upstream_health"));
+
+        set_upstream_health("192.168.1.11:8080", false);
+        let output_unhealthy = gather_metrics();
+        
+        // Verify the gauge values are present
+        assert!(output_unhealthy.contains("upstream=\"192.168.1.10:8080\""));
+        assert!(output_unhealthy.contains("upstream=\"192.168.1.11:8080\""));
+    }
+
+    #[test]
+    fn test_record_rate_limited() {
+        record_rate_limited("203.0.113.42");
+        record_rate_limited("198.51.100.1");
+        let output = gather_metrics();
+        assert!(output.contains("nexus_rate_limited_total"));
+    }
+
+    #[test]
+    fn test_record_rule_match() {
+        record_rule_match("R001", "block");
+        record_rule_match("R002", "log");
+        record_rule_match("R003", "allow");
+        let output = gather_metrics();
+        assert!(output.contains("nexus_rule_matches_total"));
+    }
+
+    #[test]
+    fn test_gather_metrics_returns_valid_output() {
+        init();
+        
+        // Record some metrics
+        record_request("GET", 200);
+        record_blocked("sqli");
+        set_active_connections(5);
+        
+        let output = gather_metrics();
+        
+        // Should contain metric names
+        assert!(output.contains("nexus_requests_total"));
+        assert!(output.contains("nexus_blocked_requests_total"));
+        assert!(output.contains("nexus_active_connections"));
+        
+        // Should be valid Prometheus format (starts with # HELP or metric names)
+        assert!(!output.is_empty());
+        assert!(output.lines().any(|line| line.starts_with("# HELP") || line.starts_with("nexus_")));
+    }
+
+    #[test]
+    fn test_all_metrics_present_after_init() {
+        init();
+        
+        // Record at least one value for each metric so they appear in output
+        record_request("GET", 200);
+        record_request_duration(Duration::from_millis(10));
+        record_blocked("test");
+        record_layer_duration("test", Duration::from_micros(100));
+        record_ml_inference(Duration::from_millis(5), false);
+        set_active_connections(0);
+        set_upstream_health("test", true);
+        record_rate_limited("test");
+        record_rule_match("test", "test");
+        
+        let output = gather_metrics();
+        
+        // All metrics should be registered and appear in output
+        assert!(output.contains("nexus_requests_total"), "Missing nexus_requests_total");
+        assert!(output.contains("nexus_request_duration_ms"), "Missing nexus_request_duration_ms");
+        assert!(output.contains("nexus_blocked_requests_total"), "Missing nexus_blocked_requests_total");
+        assert!(output.contains("nexus_layer_duration_us"), "Missing nexus_layer_duration_us");
+        assert!(output.contains("nexus_ml_inference_duration_ms"), "Missing nexus_ml_inference_duration_ms");
+        assert!(output.contains("nexus_ml_detections_total"), "Missing nexus_ml_detections_total");
+        assert!(output.contains("nexus_active_connections"), "Missing nexus_active_connections");
+        assert!(output.contains("nexus_upstream_health"), "Missing nexus_upstream_health");
+        assert!(output.contains("nexus_rate_limited_total"), "Missing nexus_rate_limited_total");
+        assert!(output.contains("nexus_rule_matches_total"), "Missing nexus_rule_matches_total");
+    }
+}

--- a/nexus-metrics/src/metrics.rs
+++ b/nexus-metrics/src/metrics.rs
@@ -1,0 +1,123 @@
+//! Metric definitions for Nexus observability.
+//!
+//! All metrics are lazily initialized and registered with the global Prometheus registry.
+
+use once_cell::sync::Lazy;
+use prometheus::{
+    register_counter_vec, register_gauge_vec, register_histogram_vec, register_counter,
+    register_histogram, register_gauge, CounterVec, GaugeVec, HistogramVec, Counter, Histogram,
+    Gauge,
+};
+
+/// Total requests by HTTP method and response status.
+pub static NEXUS_REQUESTS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "nexus_requests_total",
+        "Total number of requests by HTTP method and response status",
+        &["method", "status"]
+    )
+    .expect("failed to register nexus_requests_total")
+});
+
+/// End-to-end request duration in milliseconds.
+pub static NEXUS_REQUEST_DURATION_MS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "nexus_request_duration_ms",
+        "End-to-end request latency in milliseconds",
+        vec![1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 5000.0]
+    )
+    .expect("failed to register nexus_request_duration_ms")
+});
+
+/// Total blocked requests by reason.
+pub static NEXUS_BLOCKED_REQUESTS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "nexus_blocked_requests_total",
+        "Total number of blocked requests by reason",
+        &["reason"]
+    )
+    .expect("failed to register nexus_blocked_requests_total")
+});
+
+/// Per-layer processing time in microseconds.
+pub static NEXUS_LAYER_DURATION_US: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "nexus_layer_duration_us",
+        "Per-layer processing time in microseconds",
+        &["layer"],
+        vec![10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 50000.0]
+    )
+    .expect("failed to register nexus_layer_duration_us")
+});
+
+/// ML gRPC call duration in milliseconds.
+pub static NEXUS_ML_INFERENCE_DURATION_MS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "nexus_ml_inference_duration_ms",
+        "ML inference call duration in milliseconds",
+        vec![1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0]
+    )
+    .expect("failed to register nexus_ml_inference_duration_ms")
+});
+
+/// Total requests flagged by ML.
+pub static NEXUS_ML_DETECTIONS_TOTAL: Lazy<Counter> = Lazy::new(|| {
+    register_counter!(
+        "nexus_ml_detections_total",
+        "Total number of requests flagged by ML"
+    )
+    .expect("failed to register nexus_ml_detections_total")
+});
+
+/// Current open client connections.
+pub static NEXUS_ACTIVE_CONNECTIONS: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "nexus_active_connections",
+        "Current number of open client connections"
+    )
+    .expect("failed to register nexus_active_connections")
+});
+
+/// Upstream health status (1.0 = healthy, 0.0 = unhealthy).
+pub static NEXUS_UPSTREAM_HEALTH: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "nexus_upstream_health",
+        "Upstream health status (1.0 = healthy, 0.0 = unhealthy)",
+        &["upstream"]
+    )
+    .expect("failed to register nexus_upstream_health")
+});
+
+/// Total rate-limited requests per IP.
+pub static NEXUS_RATE_LIMITED_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "nexus_rate_limited_total",
+        "Total number of rate-limited requests per client IP",
+        &["client_ip"]
+    )
+    .expect("failed to register nexus_rate_limited_total")
+});
+
+/// Rule engine matches per rule and action.
+pub static NEXUS_RULE_MATCHES_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        "nexus_rule_matches_total",
+        "Total number of rule engine matches per rule and action",
+        &["rule_id", "action"]
+    )
+    .expect("failed to register nexus_rule_matches_total")
+});
+
+/// Force registration of all metrics at startup.
+pub fn register_all() {
+    Lazy::force(&NEXUS_REQUESTS_TOTAL);
+    Lazy::force(&NEXUS_REQUEST_DURATION_MS);
+    Lazy::force(&NEXUS_BLOCKED_REQUESTS_TOTAL);
+    Lazy::force(&NEXUS_LAYER_DURATION_US);
+    Lazy::force(&NEXUS_ML_INFERENCE_DURATION_MS);
+    Lazy::force(&NEXUS_ML_DETECTIONS_TOTAL);
+    Lazy::force(&NEXUS_ACTIVE_CONNECTIONS);
+    Lazy::force(&NEXUS_UPSTREAM_HEALTH);
+    Lazy::force(&NEXUS_RATE_LIMITED_TOTAL);
+    Lazy::force(&NEXUS_RULE_MATCHES_TOTAL);
+}

--- a/nexus-metrics/src/recorder.rs
+++ b/nexus-metrics/src/recorder.rs
@@ -1,0 +1,140 @@
+//! Public recording API for Nexus metrics.
+//!
+//! This module provides clean, type-safe functions for recording metrics
+//! without exposing raw Prometheus types to other crates.
+
+use crate::metrics::*;
+use std::time::Duration;
+
+/// Record a request with its HTTP method and response status.
+///
+/// # Example
+/// ```
+/// nexus_metrics::record_request("GET", 200);
+/// nexus_metrics::record_request("POST", 403);
+/// ```
+pub fn record_request(method: &str, status_code: u16) {
+    NEXUS_REQUESTS_TOTAL
+        .with_label_values(&[method, &status_code.to_string()])
+        .inc();
+}
+
+/// Record the end-to-end duration of a request.
+///
+/// Duration is automatically converted to milliseconds.
+///
+/// # Example
+/// ```
+/// use std::time::Duration;
+/// nexus_metrics::record_request_duration(Duration::from_millis(42));
+/// ```
+pub fn record_request_duration(duration: Duration) {
+    let millis = duration.as_secs_f64() * 1000.0;
+    NEXUS_REQUEST_DURATION_MS.observe(millis);
+}
+
+/// Record a blocked request with the reason for blocking.
+///
+/// Reasons can be: "sqli", "xss", "rule:R001", "rate_limit", etc.
+///
+/// # Example
+/// ```
+/// nexus_metrics::record_blocked("sqli");
+/// nexus_metrics::record_blocked("rule:R001");
+/// ```
+pub fn record_blocked(reason: &str) {
+    NEXUS_BLOCKED_REQUESTS_TOTAL
+        .with_label_values(&[reason])
+        .inc();
+}
+
+/// Record the processing time for a specific layer.
+///
+/// Layer names: "rate", "lexical", "grammar", "rules", "ml"
+/// Duration is automatically converted to microseconds.
+///
+/// # Example
+/// ```
+/// use std::time::Duration;
+/// nexus_metrics::record_layer_duration("lexical", Duration::from_micros(150));
+/// ```
+pub fn record_layer_duration(layer: &str, duration: Duration) {
+    let micros = duration.as_secs_f64() * 1_000_000.0;
+    NEXUS_LAYER_DURATION_US
+        .with_label_values(&[layer])
+        .observe(micros);
+}
+
+/// Record an ML inference call.
+///
+/// Duration is automatically converted to milliseconds.
+/// If `detected` is true, also increments the ML detections counter.
+///
+/// # Example
+/// ```
+/// use std::time::Duration;
+/// nexus_metrics::record_ml_inference(Duration::from_millis(8), true);
+/// nexus_metrics::record_ml_inference(Duration::from_millis(5), false);
+/// ```
+pub fn record_ml_inference(duration: Duration, detected: bool) {
+    let millis = duration.as_secs_f64() * 1000.0;
+    NEXUS_ML_INFERENCE_DURATION_MS.observe(millis);
+    
+    if detected {
+        NEXUS_ML_DETECTIONS_TOTAL.inc();
+    }
+}
+
+/// Set the current number of active client connections.
+///
+/// Use i64 to allow both incrementing and decrementing.
+///
+/// # Example
+/// ```
+/// nexus_metrics::set_active_connections(42);
+/// nexus_metrics::set_active_connections(0);
+/// ```
+pub fn set_active_connections(count: i64) {
+    NEXUS_ACTIVE_CONNECTIONS.set(count as f64);
+}
+
+/// Set the health status of an upstream server.
+///
+/// `healthy = true` sets the gauge to 1.0, `false` sets it to 0.0.
+///
+/// # Example
+/// ```
+/// nexus_metrics::set_upstream_health("192.168.1.10:8080", true);
+/// nexus_metrics::set_upstream_health("192.168.1.11:8080", false);
+/// ```
+pub fn set_upstream_health(addr: &str, healthy: bool) {
+    let value = if healthy { 1.0 } else { 0.0 };
+    NEXUS_UPSTREAM_HEALTH
+        .with_label_values(&[addr])
+        .set(value);
+}
+
+/// Record a rate-limited request from a specific client IP.
+///
+/// # Example
+/// ```
+/// nexus_metrics::record_rate_limited("203.0.113.42");
+/// ```
+pub fn record_rate_limited(client_ip: &str) {
+    NEXUS_RATE_LIMITED_TOTAL
+        .with_label_values(&[client_ip])
+        .inc();
+}
+
+/// Record a rule engine match.
+///
+/// # Example
+/// ```
+/// nexus_metrics::record_rule_match("R001", "block");
+/// nexus_metrics::record_rule_match("R002", "log");
+/// ```
+pub fn record_rule_match(rule_id: &str, action: &str) {
+    NEXUS_RULE_MATCHES_TOTAL
+        .with_label_values(&[rule_id, action])
+        .inc();
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a metrics collection module with Prometheus support for application observability
  * New metrics available for tracking requests, durations, blocked events, layer processing times, ML inference metrics, active connections, upstream health, rate limiting, and rule matches
  * Metrics exportable in Prometheus text format for integration with monitoring systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->